### PR TITLE
Fix: TypeError - 'NoneType' not iterable at 'parse_datetime_str'

### DIFF
--- a/py115/types.py
+++ b/py115/types.py
@@ -117,8 +117,10 @@ class File(_Base):
         r.name = raw.get('n')
         if 'te' in raw:
             r.modified_time = utils.parse_datetime_str(raw.get('te'))
-        else:
+        elif 't' in raw:
             r.modified_time = utils.parse_datetime_str(raw.get('t'))
+        else:
+            r.modified_time = datetime.now()
         if r.is_dir:
             r.file_id = category_id
             r.parent_id = parent_id


### PR DESCRIPTION
The script crashes when adding a new folder to the web API, displaying the error `TypeError: argument of type 'NoneType' is not iterable`.

On checking the browser at `https://webapi.115.com/files/add`, the current API response is:

```json
{
    "state": true,
    "error": "",
    "errno": "",
    "aid": 1,
    "cid": "2812162210233806149",
    "cname": "xxxxxx2",
    "file_id": "2812034560203806149",
    "file_name": "xxxxxx2"
}
```

However, `types.py` only checks for 'te' and assumes 't' exists. A workaround is to add more conditions to handle the missing modified time:

```python
if 'te' in raw:
    r.modified_time = utils.parse_datetime_str(raw.get('te'))
elif 't' in raw:
    r.modified_time = utils.parse_datetime_str(raw.get('t'))
else:
    r.modified_time = datetime.now()
```